### PR TITLE
Fix non key item pop NMs

### DIFF
--- a/EmpyPopTracker.lua
+++ b/EmpyPopTracker.lua
@@ -216,7 +216,12 @@ end
 EmpyPopTracker.generate_info = function(nm, key_items, items)
     return {
         has_all_pops = not nm.pops or T(nm.pops):all(function(item)
-            return item.type == 'item' and owns_item(item.id, items) or owns_key_item(item.id, key_items)
+            -- Avoids confusing item and key item IDs
+            if item.type == 'item' then
+                return owns_item(item.id, items)
+            end
+
+            return owns_key_item(item.id, key_items)
         end),
         text = generate_text(nm, key_items, items, 1)
     }


### PR DESCRIPTION
Recently added Ironclad NMs are popped with regular items only, not key
items. The logic for checking whether the player possessed all items
required to pop the tracked NM was flawed in that it used a ternary and
fell back to KI checking. This meant that if the player had a key item
with the same ID as the item required, EPT would display green as if the
player was ready to pop.